### PR TITLE
config: access_org_name field max lenth change to 300

### DIFF
--- a/config/optional/field.storage.node.field_access_org_name.yml
+++ b/config/optional/field.storage.node.field_access_org_name.yml
@@ -9,7 +9,7 @@ field_name: field_access_org_name
 entity_type: node
 type: string
 settings:
-  max_length: 60
+  max_length: 300
   case_sensitive: false
   is_ascii: false
 module: core


### PR DESCRIPTION
Very small change to up the field to a 300 character max. I tested on a clean Drupal site and this came through fine.